### PR TITLE
fix Gameforge misspell

### DIFF
--- a/en_US/translations.json
+++ b/en_US/translations.json
@@ -99,7 +99,7 @@
     "TOS": "I accept Terms of Service",
     "USERNAME": "Username"
   },
-  "INFO": "NosWings is a non profit project made by IT students, and not affiliated or endorsed by GameForge or Entwell.",
+  "INFO": "NosWings is a non profit project made by IT students, and not affiliated or endorsed by Gameforge or Entwell.",
   "LINKS": {
     "DOWNLOAD": "Download",
     "LOGIN": "Login",

--- a/es_ES/translations.json
+++ b/es_ES/translations.json
@@ -99,7 +99,7 @@
     "TOS": "Acepto los términos de servicio",
     "USERNAME": "Nombre de usuario"
   },
-  "INFO": "NosWings es un proyecto sin fines de lucro hecho por estudiantes de informática, y no está afiliado o respaldado por GameForge o Entwell.",
+  "INFO": "NosWings es un proyecto sin fines de lucro hecho por estudiantes de informática, y no está afiliado o respaldado por Gameforge o Entwell.",
   "LINKS": {
     "DOWNLOAD": "Descragar",
     "LOGIN": "Iniciar sesión",

--- a/fr_FR/translations.json
+++ b/fr_FR/translations.json
@@ -99,7 +99,7 @@
     "TOS": "J'accepte les Conditions d'Utilisation",
     "USERNAME": "Nom d'utilisateur"
   },
-  "INFO": "NosWings est un projet à but non lucratif fait par des étudiants en Informatique, il n'est en aucun cas associé ou supporté par GameForge ou Entwell.",
+  "INFO": "NosWings est un projet à but non lucratif fait par des étudiants en Informatique, il n'est en aucun cas associé ou supporté par Gameforge ou Entwell.",
   "LINKS": {
     "DOWNLOAD": "Téléchargement",
     "LOGIN": "Connexion",

--- a/it_IT/translations.json
+++ b/it_IT/translations.json
@@ -99,7 +99,7 @@
     "TOS": "Accetto i Termini di servizio",
     "USERNAME": "Username"
   },
-  "INFO": "NosWings è un progetto senza scopo di lucro realizzato da studenti IT, e non è affiliato o approvato da GameForge o Entwell.",
+  "INFO": "NosWings è un progetto senza scopo di lucro realizzato da studenti IT, e non è affiliato o approvato da Gameforge o Entwell.",
   "LINKS": {
     "DOWNLOAD": "Scaricare",
     "LOGIN": "Login",

--- a/pl_PL/translations.json
+++ b/pl_PL/translations.json
@@ -99,7 +99,7 @@
       "TOS": "Akceptuję Warunki Korzystania",
       "USERNAME": "Nazwa użytkownika"
   },
-  "INFO": "NosWings to projekt non-profit wykonany przez studentów IT, który nie jest powiązany ani wspierany przez GameForge lub Entwell.",
+  "INFO": "NosWings to projekt non-profit wykonany przez studentów IT, który nie jest powiązany ani wspierany przez Gameforge lub Entwell.",
   "LINKS": {
       "DOWNLOAD": "Pobierz",
       "LOGIN": "Zaloguj się",

--- a/tr_TR/translations.json
+++ b/tr_TR/translations.json
@@ -99,7 +99,7 @@
     "TOS": "I accept Terms of Service",
     "USERNAME": "Username"
   },
-  "INFO": "NosWings is a non profit project made by IT students, and not affiliated or endorsed by GameForge or Entwell.",
+  "INFO": "NosWings is a non profit project made by IT students, and not affiliated or endorsed by Gameforge or Entwell.",
   "LINKS": {
     "DOWNLOAD": "Download",
     "LOGIN": "Login",


### PR DESCRIPTION
The company's name is Gameforge, not GameForge.
Also, Gameforge name is missing in DE translation (only Entwell is present there).